### PR TITLE
Create a Petal "Edit this Page" button for HTML pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,8 @@ jobs:
           distribution: 'liberica'
       - name: Generate website (XSLT)
         id: generate
-        run: mvn -B package -Pquick-start-guide-website
+        # Override Maven properties for the Petal button url
+        run: mvn -B -Dpetal.api-url=https://petal.evolvedbinary.com -Dpetal.github-org-name=evolvedbinary -Dpetal.github-repo-name=cityehr-documentation -Dpetal.github-branch=develop -Dpetal.referrer-base-url=https://evolvedbinary.github.io/cityehr-documentation package -Pquick-start-guide-website
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload pages artifact

--- a/cityehr-quick-start-guide/pom.xml
+++ b/cityehr-quick-start-guide/pom.xml
@@ -25,6 +25,12 @@
         <fo.generated-resources>${project.build.directory}/generated-resources/fo</fo.generated-resources>
         <html.generated-resources>${project.build.directory}/generated-resources/html</html.generated-resources>
         <website.output.folder>${project.build.directory}/website</website.output.folder>
+
+        <petal.api-url>https://petal.evolvedbinary.com</petal.api-url>
+        <petal.github-org-name>evolvedbinary</petal.github-org-name>
+        <petal.github-repo-name>cityehr-documentation</petal.github-repo-name>
+        <petal.github-branch>develop</petal.github-branch>
+        <petal.referrer-base-url>https://evolvedbinary.github.io/cityehr-documentation</petal.referrer-base-url>
     </properties>
 
     <build>
@@ -207,6 +213,26 @@
                                                 <parameter>
                                                     <name>output-folder</name>
                                                     <value>${html.generated-resources}</value>
+                                                </parameter>
+                                                <parameter>
+                                                    <name>petal-api-url</name>
+                                                    <value>${petal.api-url}</value>
+                                                </parameter>
+                                                <parameter>
+                                                    <name>petal-github-org-name</name>
+                                                    <value>${petal.github-org-name}</value>
+                                                </parameter>
+                                                <parameter>
+                                                    <name>petal-github-repo-name</name>
+                                                    <value>${petal.github-repo-name}</value>
+                                                </parameter>
+                                                <parameter>
+                                                    <name>petal-github-branch</name>
+                                                    <value>${petal.github-branch}</value>
+                                                </parameter>
+                                                <parameter>
+                                                    <name>petal-referrer-base-url</name>
+                                                    <value>${petal.referrer-base-url}</value>
                                                 </parameter>
                                             </parameters>
                                             <outputDir>${html.generated-resources}</outputDir>

--- a/cityehr-quick-start-guide/src/main/xslt/create-topic-html.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/create-topic-html.xslt
@@ -3,6 +3,7 @@
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
   xmlns:hcom="http://cityehr/html/common"
+  xmlns:com="http://cityehr/common"
   exclude-result-prefixes="xs hcom ditaarch"
   version="2.0">
   
@@ -10,11 +11,18 @@
     Generates a simple HTML page from an LwDITA 'topic'.
     Author: Adam Retter
   -->
-  
+
+  <xsl:import href="common.xslt"/>
   <xsl:import href="common-html.xslt"/>
-  
+
   <xsl:output method="html" version="5.0" encoding="UTF-8" indent="yes"/>
-  
+
+  <xsl:param name="petal-api-url" />
+  <xsl:param name="petal-github-org-name" />
+  <xsl:param name="petal-github-repo-name" />
+  <xsl:param name="petal-github-branch" />
+  <xsl:param name="petal-referrer-base-url" />
+
   <xsl:variable name="authors" as="xs:string+" select="('John Chelsom', 'Stephanie Cabrera', 'Catriona Hopper', 'Jennifer Ramirez')"/>
   
   <xsl:template match="topic">
@@ -25,15 +33,27 @@
         </xsl:call-template>
       </head>
       <body>
-        <div id="top-nav">
+        <nav id="top-nav">
           <xsl:apply-templates select="." mode="top-nav"/>
+        </nav>
+
+        <!-- Petal Edit Button -->
+        <div id="petal-edit-page-button">
+          <xsl:variable name="petal-source-file-uri" select="com:document-uri(.)" />
+          <xsl:variable name="petal-source-file" select="substring-after($petal-source-file-uri, $petal-github-repo-name || '/')" />
+          <xsl:variable name="petal-webpage-filename" select="hcom:dita-filename-to-html(com:filename($petal-source-file-uri))" />
+          <xsl:variable name="petal-full-url" select="concat($petal-api-url, '?ghrepo=', $petal-github-org-name, '/', $petal-github-repo-name, '&amp;source=', $petal-source-file, '&amp;branch=', $petal-github-branch, '&amp;referer=', $petal-referrer-base-url, '/', $petal-webpage-filename)" />
+          <a href="{$petal-full-url}">
+            <input type="button" value="Edit this page" />
+          </a>
         </div>
+
         <article>
           <xsl:apply-templates select="element()" mode="body"/>
         </article>
-        <div id="bottom-nav">
+        <nav id="bottom-nav">
           <xsl:apply-templates select="." mode="bottom-nav"/>
-        </div>
+        </nav>
       </body>
     </html>
   </xsl:template>


### PR DESCRIPTION
### PR Description

This PR will create a HTML section containing a link button with a redirect `href` attribute to the Petal web application.

* set default values for mvn parameters, which can be overridden with custom properties when calling the build script for generating the website
* update build script for GitHub Action with custom properties for generating the website
* create a "Petal Edit this Page" for each topic page that contains a `href` attribute with required parameters for a valid redirect to the Petal Editor Application
* Parameters for the button contain:
    - `ghrepo` (`$petal-github-base-url` + `$petal-github-org-name` + `$petal-github-repo-name`)
    - `source` (xslt string processing),
    - `branch` (`$petal-github-branch`)
    - `referer` (`$petal-referrer-url`)

### How to test this PR

#### General Test

1. Generate the website with the default parameters: `mvn clean package -Pquick-start-guide-website`.
2. Open any of the generated HTML files in path `cityehr-quick-start-guide/target/website`.
3. Check the href attribute of the button under the top navigation with label "Edit this Page". It should contain the above listed parameters with the correct values.
4. Click on the link to see at least the correct redirect to the Petal production site. 

#### Test the GitHub Integration

1. Generate the website with a custom `petal.base-url` parameter to point to the Petal server instance with the running GitHub integration feature: E.g. `mvn clean -Dpetal.base-url=<YOUR_CUSTOM_URL_HERE> package -Pquick-start-guide-website`
