### PR TITLE
Correct the source param in the edit me button

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Generate website (XSLT)
         id: generate
         # Override Maven properties for the Petal button url
-        run: mvn -B -Dpetal.api-url=https://petal.evolvedbinary.com -Dpetal.github-org-name=evolvedbinary -Dpetal.github-repo-name=cityehr-documentation -Dpetal.github-branch=develop -Dpetal.referrer-base-url=https://evolvedbinary.github.io/cityehr-documentation package -Pquick-start-guide-website
+        run: mvn -B -Dpetal.api-url=http://dev.petal.evolvedbinary.com -Dpetal.github-org-name=evolvedbinary -Dpetal.github-repo-name=cityehr-documentation -Dpetal.github-branch=develop -Dpetal.referrer-base-url=https://evolvedbinary.github.io/cityehr-documentation package -Pquick-start-guide-website
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload pages artifact

--- a/cityehr-quick-start-guide/src/main/xslt/create-topic-html.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/create-topic-html.xslt
@@ -130,7 +130,7 @@
   <xsl:function name="htop:petal-edit-url" as="xs:string">
     <xsl:param name="topic" as="element(topic)" required="yes"/>
     <xsl:variable name="petal-source-file-uri" select="com:document-uri($topic)" />
-    <xsl:variable name="petal-source-file" select="substring-after($petal-source-file-uri, concat($petal-github-repo-name, '/'))" />
+    <xsl:variable name="petal-source-file" select="substring-after($petal-source-file-uri, concat($petal-github-repo-name,  '/', $petal-github-repo-name,  '/'))" />
     <xsl:variable name="petal-webpage-filename" select="hcom:dita-filename-to-html(com:filename($petal-source-file-uri))" />
     <xsl:sequence select="concat($petal-api-url, '?ghrepo=', $petal-github-org-name, '/', $petal-github-repo-name, '&amp;source=', $petal-source-file, '&amp;branch=', $petal-github-branch, '&amp;referer=', $petal-referrer-base-url, '/', $petal-webpage-filename)" />
   </xsl:function>


### PR DESCRIPTION
Fixes the source in the Edit ME button: http://dev.petal.evolvedbinary.com/?ghrepo=evolvedbinary/cityehr-documentation&source=cityehr-documentation/cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita&branch=develop&referer=https://evolvedbinary.github.io/cityehr-documentation/verify-install.html
If we break it down we will see the `source` is
```
source=cityehr-documentation/cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita
```
Which is wrong it should be
```
source=cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita
```