### PR TITLE
Retrieve correct Petal source file parameter from file URI

### DIFF
--- a/cityehr-quick-start-guide/src/main/xslt/create-topic-html.xslt
+++ b/cityehr-quick-start-guide/src/main/xslt/create-topic-html.xslt
@@ -135,7 +135,8 @@
     <xsl:param name="petal-github-branch"     as="xs:string" required="yes"/>
     <xsl:param name="petal-referrer-base-url" as="xs:string" required="yes"/>
 
-    <xsl:variable name="petal-source-file" select="substring-after($petal-source-file-uri, concat($petal-github-repo-name, '/'))" />
+    <xsl:variable name="petal-source-file-uri-tokens" select="tokenize($petal-source-file-uri, concat($petal-github-repo-name, '/'))" />
+    <xsl:variable name="petal-source-file" select="$petal-source-file-uri-tokens[last()]" />
     <xsl:variable name="petal-webpage-filename" select="hcom:dita-filename-to-html(com:filename($petal-source-file-uri))" />
     <xsl:sequence select="concat($petal-api-url, '?ghrepo=', $petal-github-org-name, '/', $petal-github-repo-name, '&amp;source=', $petal-source-file, '&amp;branch=', $petal-github-branch, '&amp;referer=', $petal-referrer-base-url, '/', $petal-webpage-filename)" />
   </xsl:function>

--- a/cityehr-quick-start-guide/src/test/xspec/create-topic-html.xspec
+++ b/cityehr-quick-start-guide/src/test/xspec/create-topic-html.xspec
@@ -11,9 +11,21 @@
   <x:param name="petal-github-branch"     as="xs:string">develop</x:param>
   <x:param name="petal-referrer-base-url" as="xs:string">https://evolvedbinary.github.io/cityehr-documentation</x:param>
   
-  <x:scenario label="Scenario for testing the petal-edit-url function">
+  <x:scenario label="Scenario for testing the petal-edit-url function with source file from local filesytem">
     <x:call function="htop:petal-edit-url">
       <x:param name="petal-source-file-uri"   as="xs:string">file:/Users/aretter/code/evolvedbinary/customers/cityehr/cityehr-documentation/cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita</x:param>
+      <x:param name="petal-api-url"           as="xs:string">https://petal.evolvedbinary.com</x:param>
+      <x:param name="petal-github-org-name"   as="xs:string">evolvedbinary</x:param>
+      <x:param name="petal-github-repo-name"  as="xs:string">cityehr-documentation</x:param>
+      <x:param name="petal-github-branch"     as="xs:string">develop</x:param>
+      <x:param name="petal-referrer-base-url" as="xs:string">https://evolvedbinary.github.io/cityehr-documentation</x:param>
+    </x:call>
+    <x:expect label="Correct Petal Edit URL" select="'https://petal.evolvedbinary.com?ghrepo=evolvedbinary/cityehr-documentation&amp;source=cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita&amp;branch=develop&amp;referer=https://evolvedbinary.github.io/cityehr-documentation/verify-install.html'"/>
+  </x:scenario>
+  
+  <x:scenario label="Scenario for testing the petal-edit-url function with source file in GitHub Action container">
+    <x:call function="htop:petal-edit-url">
+      <x:param name="petal-source-file-uri"   as="xs:string">file:/home/runner/work/cityehr-documentation/cityehr-documentation/cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita</x:param>
       <x:param name="petal-api-url"           as="xs:string">https://petal.evolvedbinary.com</x:param>
       <x:param name="petal-github-org-name"   as="xs:string">evolvedbinary</x:param>
       <x:param name="petal-github-repo-name"  as="xs:string">cityehr-documentation</x:param>


### PR DESCRIPTION
Re-instate tokenising the source file URI to split the string after the last occurrence of the GitHub repo name. In GitHub pages the source file URI contains a URI like e.g. `/home/runner/work/cityehr-documentation/cityehr-documentation/cityehr-quick-start-guide/src/main/lwdita/quickstart-guide-modular/verify-install.dita` with a duplicate part `$petal-github-repo-name`. In other filesystems this might be different and only occur once.

Updated the xspec test to prove that the sourcefile will always be transformed correctly.